### PR TITLE
DWT-339 Site Waste Authorisation number [Array]

### DIFF
--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -497,6 +497,7 @@ components:
       type: object
       required:
         - organisationName
+        - authorisationNumbers
       properties:
         organisationName:
           type: string
@@ -515,7 +516,7 @@ components:
           items:
             type: string
           description: |
-            This is an array of the site's authorisation (permit or exemption) numbers that allows it to accept waste for intended recovery and disposal operation.
+            This is an array of the site's authorisation (permit or exemption) numbers that allows it to accept waste for intended recovery and disposal operation. At least one authorisation number is required.
               <p>Home Nations Codes:</p>
               <p><font color="blue"><b>Wales (NRW):</b></font></p>
               XX9999XX, EPR/XX9999XX

--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -511,6 +511,7 @@ components:
           example: 020 4756 XXXX
         authorisationNumbers:
           type: array
+          minItems: 1
           items:
             type: string
           description: |
@@ -532,7 +533,6 @@ components:
           type: array
           items:
             type: integer
-            minimum: 1
           description: |
             An array of regulatory position statement (RPS) numbers. A regulatory position statement is issued when the Regulator (EA, SEPA, NIEA, NRW), doesn't require you to have a permit to carry out certain activities that they regulate. The statement will explain which activities you do not require a permit for. Each must be a positive integer.
             <p><font color="green"><b>Business Rule:</b></font></p>

--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -511,7 +511,6 @@ components:
           example: 020 4756 XXXX
         authorisationNumbers:
           type: array
-          minItems: 1
           items:
             type: string
           description: |
@@ -533,6 +532,7 @@ components:
           type: array
           items:
             type: integer
+            minimum: 1
           description: |
             An array of regulatory position statement (RPS) numbers. A regulatory position statement is issued when the Regulator (EA, SEPA, NIEA, NRW), doesn't require you to have a permit to carry out certain activities that they regulate. The statement will explain which activities you do not require a permit for. Each must be a positive integer.
             <p><font color="green"><b>Business Rule:</b></font></p>


### PR DESCRIPTION
### Description
Ticket [DWT-345](https://eaflood.atlassian.net/browse/DWT-345) [
This pull request updates the Receipt API schema to enhance its clarity and validation rules:

- Added `authorisationNumbers` as a mandatory field in the API specification to ensure stricter compliance with site authorisation requirements.



[DWT-345]: https://eaflood.atlassian.net/browse/DWT-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ