### PR TITLE
DWT-624 Hazardous components validation

### DIFF
--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -393,7 +393,7 @@ components:
               items:
                 type: object
                 required:
-                  - required
+                  - name
                 properties:
                   name:
                     type: string

--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -299,9 +299,43 @@ components:
                   name:
                     type: string
                     description: |
-                      The name of the POP e.g.  Persistant Organic Pollutant (POP). <ul> <li>Aldrin,</li> <li>Chlordane,</li> <li>Chlordecone,</li> <li>Dicofol,</li> <li>Dieldrin,</li> <li>Endrin,</li> <li>Heptachlor,</li> <li>Hexabromobiphenyl,</li> <li>Hexabromocyclododecane (HBCDD),</li> <li>Hexabromodiphenyl ether and heptabromodiphenyl ether,</li> <li>Hexachlorobenzene (HCB),</li> <li>Hexachlorobutadiene,</li> <li>Alpha hexachlorocyclohexane,</li> <li>Beta hexachlorocyclohexane, </li> <li>Lindane,</li> <li>Mirex,</li> <li>Pentachlorobenzene,</li> <li>Polychlorinated biphenyls (PCB),</li> <li>Toxaphene,</li> <li>DDT,</li> <li>Perfluorooctane sulfonic acid (PFOS) its salts and perfluorooctane sulfonyl fluorid,</li> <li>Chlordane,</li> <li>Polychlorinated dibenzo-p-dioxins (PCDD),</li> <li>Polychlorinated dibenzofurans (PCDF),</li> <li>UV-328 </li><li>Details not provided by carrier</li></ul> <p> A full list is provided in the Stockholm Convention on Persistent Organic Pollutants (POPs) which can be found here:</p> <a> https://www.pops.int/TheConvention/ThePOPs/AllPOPs/tabid/2509/Default.aspx</a> <p>See also Annex B and Annex C in this document for Restricted and Unintentional releases of chemicals respectively.</p> 
-                        <p><font color="green"><b>Business Rule:</b></font></p>
-                        Must be a valid POP name from the list above.
+                      The name of the POP e.g.  Persistant Organic Pollutant (POP).
+                      <ul>
+                      <li>Endosulfan,</li>
+                      <li>Hexachlorobutadiene,</li>
+                      <li>Polychlorinated naphthalenes,</li>
+                      <li>SCCPs,</li>
+                      <li>Tetrabromodiphenyl ether,</li>
+                      <li>Pentabromodiphenyl ether,</li>
+                      <li>Hexabromodiphenyl ether,</li>
+                      <li>Heptabromodiphenyl ether,</li>
+                      <li>Decabromodiphenyl ether,</li>
+                      <li>Tetra-, penta-, hexa-, hepta- and deca- bromodiphenyl ether,</li>
+                      <li>PFOS,</li>
+                      <li>PCDD/PCDF,</li>
+                      <li>DDT,</li>
+                      <li>Chlordane,</li>
+                      <li>Hexachlorocyclohexanes,</li>
+                      <li>Dieldrin,</li>
+                      <li>Endrin,</li>
+                      <li>Heptachlor,</li>
+                      <li>Hexachlorobenzene,</li>
+                      <li>Chlordecone,</li>
+                      <li>Aldrin,</li>
+                      <li>Pentachlorobenzene,</li>
+                      <li>PCB,</li>
+                      <li>Mirex,</li>
+                      <li>Toxaphene,</li>
+                      <li>Hexabromobiphenyl,</li>
+                      <li>Hexabromocyclododecane,</li>
+                      <li>Pentachlorophenol,</li>
+                      <li>PFOA,</li>
+                      <li>Dicofol,</li>
+                      <li>PFHxS</li>
+                      </ul>
+                      <p> A full list is provided in the Stockholm Convention on Persistent Organic Pollutants (POPs) which can be found here:</p> <a> https://www.pops.int/TheConvention/ThePOPs/AllPOPs/tabid/2509/Default.aspx</a> <p>See also Annex B and Annex C in this document for Restricted and Unintentional releases of chemicals respectively.</p> 
+                      <p><font color="green"><b>Business Rule:</b></font></p>
+                      Must be a valid POP name from the list above.
                     example: Aldrin, Chlordane, Dieldrin.
                   concentration:
                     type: number

--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -334,10 +334,8 @@ components:
                 - CARRIER_PROVIDED: Components provided by carrier
                 - GUIDANCE: Components determined from guidance
                 - OWN_TESTING: Components determined from own testing
-                <p><font color="green"><b>Business Rules:</b></font></p>
+                <p><font color="green"><b>Business Rule:</b></font></p>
                 - Must be provided when containsHazardous is true
-                - If sourceOfComponents is NOT_PROVIDED, components array must be empty or not provided
-                - If sourceOfComponents is CARRIER_PROVIDED, GUIDANCE, or OWN_TESTING, the system will accept submission but provide a validation warning if no components are provided
               example: CARRIER_PROVIDED
             hazCodes:
               type: array
@@ -360,6 +358,8 @@ components:
               type: array
               items:
                 type: object
+                required:
+                  - required
                 properties:
                   name:
                     type: string
@@ -373,6 +373,12 @@ components:
                       <p><font color="green"><b>Business Rule:</b></font></p>
                       Optional field. If provided, must be a positive numeric value.
                     example: 50
+            description: |
+                The list of Hazardous components.
+                <p><font color="green"><b>Business Rules:</b></font></p>
+                - Must be provided when containsHazardous is true
+                - If sourceOfComponents is NOT_PROVIDED, components array must be empty or not provided
+                - If sourceOfComponents is CARRIER_PROVIDED, GUIDANCE, or OWN_TESTING, the system will accept submission but provide a validation warning if an empty components array is provided
         disposalOrRecoveryCodes:
           type: array
           items:


### PR DESCRIPTION
Ticket [DWT-624](https://eaflood.atlassian.net/browse/DWT-624)

Changes:
- Update Hazardous component name to be required
- Update Hazardous sourceOfComponents/components description
- Update POP component name examples

[DWT-624]: https://eaflood.atlassian.net/browse/DWT-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ