### PR TITLE
New Reference Data GET Endpoints

### DIFF
--- a/docs/apiSpecifications/Receipt API.yml
+++ b/docs/apiSpecifications/Receipt API.yml
@@ -113,7 +113,7 @@ paths:
                     code:
                       type: string
                       description: The hazardous property code.
-                      example: HP_01
+                      example: HP_1
 components:
   requestBodies:
     receiveMovementRequest:


### PR DESCRIPTION
This PR is to collect the Swagger spec changes to add the new Reference Data endpoints.

The PR can be merged once we've started versioning the Swagger spec, so we don't add endpoints to the spec that don't exist in the API yet.