### PR TITLE
Added - disposalOrRecoveryCodes as required to line 520

### DIFF
--- a/docs/apiSpecifications/ReceiptAPI.yml
+++ b/docs/apiSpecifications/ReceiptAPI.yml
@@ -517,6 +517,7 @@ components:
         - weight
         - containsPops
         - containsHazardous
+        - disposalOrRecoveryCodes
       properties:
         ewcCodes:
           type: array


### PR DESCRIPTION
To ensure disposalOrRecoveryCodes appears mandatory in the Data Properties section of the Swagger.