### PR TITLE
Updated API Spec to make disposalOrRecoveryCodes optional

### DIFF
--- a/docs/apiSpecifications/ReceiptAPI.yml
+++ b/docs/apiSpecifications/ReceiptAPI.yml
@@ -536,7 +536,6 @@ components:
         - weight
         - containsPops
         - containsHazardous
-        - disposalOrRecoveryCodes
       properties:
         ewcCodes:
           type: array


### PR DESCRIPTION
Removed 'disposalOrRecoveryCodes' from WasteItem required list